### PR TITLE
Add support for overriding template dir

### DIFF
--- a/gotestfmt.go
+++ b/gotestfmt.go
@@ -17,11 +17,12 @@ import (
 var fs embed.FS
 
 func New(
+	templateRoot string,
 	templateDirs []string,
 ) (CombinedExitCode, error) {
-	downloadsTpl := findTemplate(templateDirs, "downloads.gotpl")
+	downloadsTpl := findTemplate(templateRoot, templateDirs, "downloads.gotpl")
 
-	packageTpl := findTemplate(templateDirs, "package.gotpl")
+	packageTpl := findTemplate(templateRoot, templateDirs, "package.gotpl")
 
 	return &goTestFmt{
 		downloadsTpl: downloadsTpl,
@@ -29,17 +30,17 @@ func New(
 	}, nil
 }
 
-func findTemplate(dirs []string, tpl string) []byte {
+func findTemplate(root string, dirs []string, tpl string) []byte {
 	var lastError error
 	for _, dir := range dirs {
-		templateContents, err := os.ReadFile(path.Join(dir, tpl))
+		templateContents, err := os.ReadFile(path.Join(root, dir, tpl))
 		if err == nil {
 			return templateContents
 		}
 		lastError = err
 	}
 	for _, dir := range dirs {
-		templateContents, err := fs.ReadFile(path.Join(dir, tpl))
+		templateContents, err := fs.ReadFile(path.Join("./.gotestfmt", dir, tpl))
 		if err == nil {
 			return templateContents
 		}
@@ -49,6 +50,7 @@ func findTemplate(dirs []string, tpl string) []byte {
 }
 
 // Combined is an interface that combines both the classic GoTestFmt interface and the Formatter interface.
+//
 //goland:noinspection GoDeprecation
 type Combined interface {
 	GoTestFmt
@@ -64,6 +66,7 @@ type CombinedExitCode interface {
 // GoTestFmt implements the classic Format instruction. This is no longer in use.
 //
 // Deprecated: please use the Formatter interface instead.
+//
 //goland:noinspection GoDeprecation
 type GoTestFmt interface {
 	Format(input io.Reader, target io.WriteCloser)


### PR DESCRIPTION
## Please describe the change you are making

I'm using some custom templates for output formatting, and trying to share them between projects. 
As it stands, I have to follow an overly complex routine of writing test output json to a file, `cd`-ing to my templates folder and then executing `gotestfmt` using the `-input` flag. It shouldn't be this hard 😭 

To make (my own) life easier, I've added an optional `-template-dir` flag to the cli that allows overriding the base path for template lookups. This way you can point at whatever template folder you want elsewhere on the filesystem.
To maintain b/c it defaults to `./.gotestfmt`.


...

## Your code will be released under [the Unlicense](LICENSE.md) into the public domain for everyone to use for any purpose. Are you in the position, and are you willing to release your code under this license?
👍 