### PR TITLE
A hash character at the beginning of Output line causes test to be marked as failed

### DIFF
--- a/testdata/issue-52.parser.json
+++ b/testdata/issue-52.parser.json
@@ -1,0 +1,27 @@
+{
+  "prefix": null,
+  "downloads": {
+    "packages": null,
+    "failed": false,
+    "reason": ""
+  },
+  "packages": [
+    {
+      "name": "code-intelligence.com/cifuzz/integration-tests/other",
+      "result": "",
+      "duration": "0s",
+      "coverage": null,
+      "output": "",
+      "testcases": [
+        {
+          "name": "TestIntegration_Other_RunCoverage",
+          "result": "FAIL",
+          "duration": "0s",
+          "coverage": null,
+          "output": "The FUZZ_TEST_CXXFLAGS and FUZZ_TEST_LDFLAGS environment variables"
+        }
+      ],
+      "reason": ""
+    }
+  ]
+}

--- a/testdata/issue-52.parser.json
+++ b/testdata/issue-52.parser.json
@@ -18,7 +18,7 @@
           "result": "FAIL",
           "duration": "0s",
           "coverage": null,
-          "output": "The FUZZ_TEST_CXXFLAGS and FUZZ_TEST_LDFLAGS environment variables"
+          "output": "# The FUZZ_TEST_CXXFLAGS and FUZZ_TEST_LDFLAGS environment variables"
         }
       ],
       "reason": ""

--- a/testdata/issue-52.tokenizer.json
+++ b/testdata/issue-52.tokenizer.json
@@ -1,0 +1,13 @@
+[
+  {
+    "action": "stdout",
+    "package": "code-intelligence.com/cifuzz/integration-tests/other",
+    "version": "",
+    "test": "TestIntegration_Other_RunCoverage",
+    "elapsed": "0s",
+    "output": "VGhlIEZVWlpfVEVTVF9DWFhGTEFHUyBhbmQgRlVaWl9URVNUX0xERkxBR1MgZW52aXJvbm1lbnQgdmFyaWFibGVz",
+    "cached": false,
+    "coverage": null,
+    "json": true
+  }
+]

--- a/testdata/issue-52.tokenizer.json
+++ b/testdata/issue-52.tokenizer.json
@@ -5,7 +5,7 @@
     "version": "",
     "test": "TestIntegration_Other_RunCoverage",
     "elapsed": "0s",
-    "output": "VGhlIEZVWlpfVEVTVF9DWFhGTEFHUyBhbmQgRlVaWl9URVNUX0xERkxBR1MgZW52aXJvbm1lbnQgdmFyaWFibGVz",
+    "output": "IyBUaGUgRlVaWl9URVNUX0NYWEZMQUdTIGFuZCBGVVpaX1RFU1RfTERGTEFHUyBlbnZpcm9ubWVudCB2YXJpYWJsZXM=",
     "cached": false,
     "coverage": null,
     "json": true

--- a/testdata/issue-52.txt
+++ b/testdata/issue-52.txt
@@ -1,1 +1,1 @@
-{"Time":"2023-05-26T14:52:41.180732Z","Action":"output","Package":"code-intelligence.com/cifuzz/integration-tests/other","Test":"TestIntegration_Other_RunCoverage","Output":"The FUZZ_TEST_CXXFLAGS and FUZZ_TEST_LDFLAGS environment variables\n"}
+{"Time":"2023-05-26T14:52:41.180732Z","Action":"output","Package":"code-intelligence.com/cifuzz/integration-tests/other","Test":"TestIntegration_Other_RunCoverage","Output":"# The FUZZ_TEST_CXXFLAGS and FUZZ_TEST_LDFLAGS environment variables\n"}

--- a/testdata/issue-52.txt
+++ b/testdata/issue-52.txt
@@ -1,0 +1,1 @@
+{"Time":"2023-05-26T14:52:41.180732Z","Action":"output","Package":"code-intelligence.com/cifuzz/integration-tests/other","Test":"TestIntegration_Other_RunCoverage","Output":"The FUZZ_TEST_CXXFLAGS and FUZZ_TEST_LDFLAGS environment variables\n"}

--- a/tokenizer/tokenizer.go
+++ b/tokenizer/tokenizer.go
@@ -418,6 +418,11 @@ func parseLine(currentState state, line []byte, output chan<- Event) state {
 			continue
 		}
 
+		// Don't match the "package" action against a JSON lines - issue #52
+		if jsonLine != nil && stateTransition.action == ActionPackage {
+			continue
+		}
+
 		if match := stateTransition.regexp.FindSubmatch(line); len(match) != 0 {
 			elapsed, err := getTimeElapsed(stateTransition.regexp, match, "Elapsed")
 			if err == nil {


### PR DESCRIPTION
I noticed that when an `output` line starts with `#`, it's matched against tokenizer regex for Packages:

https://github.com/GoTestTools/gotestfmt/blob/9eae5abc81d6d08f73268741ef4a8b97f29b60d8/tokenizer/tokenizer.go#L51-L62

This manifest as the output lines with `#` like:


```
{"Time":"2023-05-26T14:52:41.180732Z","Action":"output","Package":"code-intelligence.com/cifuzz/integration-tests/other","Test":"TestIntegration_Other_RunCoverage","Output":"# The FUZZ_TEST_CXXFLAGS and FUZZ_TEST_LDFLAGS environment variables\n"}
{"Time":"2023-05-26T14:52:41.185726Z","Action":"output","Package":"code-intelligence.com/cifuzz/integration-tests/other","Test":"TestIntegration_Other_RunCoverage","Output":"# are set by cifuzz when it executes the build command. Those must\n"}
{"Time":"2023-05-26T14:52:41.190079Z","Action":"output","Package":"code-intelligence.com/cifuzz/integration-tests/other","Test":"TestIntegration_Other_RunCoverage","Output":"# be passed to the compiler and linker (compiling and linking is\n"}
{"Time":"2023-05-26T14:52:41.194327Z","Action":"output","Package":"code-intelligence.com/cifuzz/integration-tests/other","Test":"TestIntegration_Other_RunCoverage","Output":"# done in a single invocation here, so we pass both to XX here).\n"}
```


are printed instead of the package/test name and exit code is non-zero:
<img width="1012" alt="Screenshot 2023-05-29 at 15 29 19" src="https://github.com/GoTestTools/gotestfmt/assets/1788727/4dc3d6fb-1af4-40e4-9ccb-e3b5e9e93306">

-

This PR matches the "action" regex only against non-JSON lines.
